### PR TITLE
Add support for Polymesh SubQuery V19.0.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# GraphQL Endpoints
+NEXT_PUBLIC_GRAPHQL_ENDPOINT=https://mainnet-graphql.polymesh.network
+NEXT_PUBLIC_GRAPHQL_ENDPOINT_TESTNET=https://testnet-graphql.polymesh.live 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@mui/toolpad-core": "^0.1.51",
     "@polkadot/types": "^11.3.1",
     "@polkadot/ui-identicon": "^0.41.1",
-    "@polymeshassociation/polymesh-sdk": "26.2.0",
+    "@polymeshassociation/polymesh-sdk": "27.3.0",
     "@tanstack/react-query": "^5.62.0",
     "@toolpad/core": "^0.7.0",
     "@toolpad/studio-runtime": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^0.41.1
         version: 0.41.1(@babel/core@7.26.0)(@polkadot/keyring@13.1.1(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2))(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@polymeshassociation/polymesh-sdk':
-        specifier: 26.2.0
-        version: 26.2.0(@types/react@18.3.12)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(utf-8-validate@5.0.10)
+        specifier: 27.3.0
+        version: 27.3.0(@types/react@18.3.12)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(utf-8-validate@5.0.10)
       '@tanstack/react-query':
         specifier: ^5.62.0
         version: 5.62.0(react@18.3.1)
@@ -86,10 +86,10 @@ importers:
         version: 8.57.1
       eslint-config-airbnb:
         specifier: 19.0.4
-        version: 19.0.4(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1)
+        version: 19.0.4(eslint-plugin-import@2.31.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1)
       eslint-config-airbnb-typescript:
         specifier: ^18.0.0
-        version: 18.0.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1)
+        version: 18.0.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-plugin-import@2.31.0)(eslint@8.57.1)
       eslint-config-next:
         specifier: 14.2.9
         version: 14.2.9(eslint@8.57.1)(typescript@5.7.2)
@@ -98,7 +98,7 @@ importers:
         version: 9.1.0(eslint@8.57.1)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+        version: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@8.57.1)
@@ -1231,8 +1231,8 @@ packages:
     resolution: {integrity: sha512-cGZWo7K5eRRQCRl2LrcyCYsrc3lRbTlixZh3AzgU8uX4wASVGRlNWi/Hf4TtHNe1ExCDmxabJzdIsABIfrr7xw==}
     engines: {node: '>=18'}
 
-  '@polymeshassociation/polymesh-sdk@26.2.0':
-    resolution: {integrity: sha512-1zdaaAWVu5PgcajMokgzcsf0vjQsaC9v+ILu193JAfZbwKSEPx4y+KSsK0kehMF93tm+K1jU3uMYWsefHgwpsg==}
+  '@polymeshassociation/polymesh-sdk@27.3.0':
+    resolution: {integrity: sha512-Ch3Jg4oy1LwLjCV0deOXFUF5C2nxqbtdxjhHWl+dqXCM8ZobinA4SbSlvWnktwj7AUMfEJhgRUFL3kx5AR1XpQ==}
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
@@ -1622,9 +1622,6 @@ packages:
     resolution: {integrity: sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==}
     engines: {node: '>=8'}
 
-  '@yarnpkg/lockfile@1.1.0':
-    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1713,10 +1710,6 @@ packages:
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
-
-  at-least-node@1.0.0:
-    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
-    engines: {node: '>= 4.0.0'}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -1810,10 +1803,6 @@ packages:
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
-
-  ci-info@3.9.0:
-    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
-    engines: {node: '>=8'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -2325,9 +2314,6 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
-  find-yarn-workspace-root@2.0.0:
-    resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
-
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -2349,10 +2335,6 @@ packages:
   fractional-indexing@3.2.0:
     resolution: {integrity: sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
-
-  fs-extra@9.1.0:
-    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
-    engines: {node: '>=10'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -2556,11 +2538,6 @@ packages:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
     engines: {node: '>= 0.4'}
 
-  is-docker@2.2.1:
-    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
-    engines: {node: '>=8'}
-    hasBin: true
-
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2646,10 +2623,6 @@ packages:
   is-what@3.14.1:
     resolution: {integrity: sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==}
 
-  is-wsl@2.2.0:
-    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
-    engines: {node: '>=8'}
-
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -2714,9 +2687,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsonfile@6.1.0:
-    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
-
   jsonify@0.0.1:
     resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
 
@@ -2726,9 +2696,6 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
-  klaw-sync@6.0.0:
-    resolution: {integrity: sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -2934,10 +2901,6 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  open@7.4.2:
-    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
-    engines: {node: '>=8'}
-
   oppa@0.4.0:
     resolution: {integrity: sha512-DFvM3+F+rB/igo3FRnkDWitjZgBH9qZAn68IacYHsqbZBKwuTA+LdD4zSJiQtgQpWq7M08we5FlGAVHz0yW7PQ==}
     engines: {node: '>=10'}
@@ -2948,10 +2911,6 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
-
-  os-tmpdir@1.0.2:
-    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
-    engines: {node: '>=0.10.0'}
 
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
@@ -2972,11 +2931,6 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
-
-  patch-package@8.0.0:
-    resolution: {integrity: sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==}
-    engines: {node: '>=14', npm: '>5'}
-    hasBin: true
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3199,11 +3153,6 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
@@ -3287,10 +3236,6 @@ packages:
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
-
-  slash@2.0.0:
-    resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
-    engines: {node: '>=6'}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -3460,10 +3405,6 @@ packages:
     resolution: {integrity: sha512-TARUb7z1pGvlLxgPk++7wJ6aycXF3GJ0sNSBTAsTuJrQG5QuZlkUQP+zl+nbjAh4gMX9yDw9ZYklMd7vAfJKEw==}
     engines: {node: '>=0.10.0'}
 
-  tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
-    engines: {node: '>=0.6.0'}
-
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -3530,10 +3471,6 @@ packages:
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
-
-  universalify@2.0.1:
-    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
-    engines: {node: '>= 10.0.0'}
 
   update-browserslist-db@1.1.1:
     resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
@@ -3707,11 +3644,6 @@ packages:
 
   yaml@2.5.1:
     resolution: {integrity: sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==}
-    engines: {node: '>= 14'}
-    hasBin: true
-
-  yaml@2.6.1:
-    resolution: {integrity: sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==}
     engines: {node: '>= 14'}
     hasBin: true
 
@@ -4962,7 +4894,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@polymeshassociation/polymesh-sdk@26.2.0(@types/react@18.3.12)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(utf-8-validate@5.0.10)':
+  '@polymeshassociation/polymesh-sdk@27.3.0(@types/react@18.3.12)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(utf-8-validate@5.0.10)':
     dependencies:
       '@apollo/client': 3.11.10(@types/react@18.3.12)(graphql@16.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@polkadot/api': 11.2.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -4977,7 +4909,6 @@ snapshots:
       iso-7064: 1.1.0
       json-stable-stringify: 1.1.1
       lodash: 4.17.21
-      patch-package: 8.0.0
       semver: 7.6.3
       websocket: 1.0.35
     transitivePeerDependencies:
@@ -5477,8 +5408,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@yarnpkg/lockfile@1.1.0': {}
-
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:
       acorn: 8.14.0
@@ -5585,8 +5514,6 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
-  at-least-node@1.0.0: {}
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.0.0
@@ -5687,8 +5614,6 @@ snapshots:
       supports-color: 7.2.0
 
   check-error@2.1.1: {}
-
-  ci-info@3.9.0: {}
 
   client-only@0.0.1: {}
 
@@ -6056,29 +5981,29 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.57.1
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       object.assign: 4.1.5
       object.entries: 1.1.8
       semver: 6.3.1
 
-  eslint-config-airbnb-typescript@18.0.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-airbnb-typescript@18.0.0(@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2))(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.7.2)
       eslint: 8.57.1
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - eslint-plugin-import
 
-  eslint-config-airbnb@19.0.4(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-airbnb@19.0.4(eslint-plugin-import@2.31.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.2(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.2(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -6093,8 +6018,8 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.7.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.2(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -6117,37 +6042,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.7(supports-color@5.5.0)
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.3.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.7.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -6158,7 +6083,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -6376,10 +6301,6 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  find-yarn-workspace-root@2.0.0:
-    dependencies:
-      micromatch: 4.0.8
-
   flat-cache@3.2.0:
     dependencies:
       flatted: 3.3.2
@@ -6402,13 +6323,6 @@ snapshots:
       fetch-blob: 3.2.0
 
   fractional-indexing@3.2.0: {}
-
-  fs-extra@9.1.0:
-    dependencies:
-      at-least-node: 1.0.0
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.1
 
   fs.realpath@1.0.0: {}
 
@@ -6611,8 +6525,6 @@ snapshots:
     dependencies:
       has-tostringtag: 1.0.2
 
-  is-docker@2.2.1: {}
-
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.0:
@@ -6685,10 +6597,6 @@ snapshots:
 
   is-what@3.14.1: {}
 
-  is-wsl@2.2.0:
-    dependencies:
-      is-docker: 2.2.1
-
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -6747,12 +6655,6 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsonfile@6.1.0:
-    dependencies:
-      universalify: 2.0.1
-    optionalDependencies:
-      graceful-fs: 4.2.11
-
   jsonify@0.0.1: {}
 
   jsx-ast-utils@3.3.5:
@@ -6765,10 +6667,6 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
-
-  klaw-sync@6.0.0:
-    dependencies:
-      graceful-fs: 4.2.11
 
   language-subtag-registry@0.3.23: {}
 
@@ -6964,11 +6862,6 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  open@7.4.2:
-    dependencies:
-      is-docker: 2.2.1
-      is-wsl: 2.2.0
-
   oppa@0.4.0:
     dependencies:
       chalk: 4.1.2
@@ -6988,8 +6881,6 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
-
-  os-tmpdir@1.0.2: {}
 
   p-finally@1.0.0: {}
 
@@ -7011,24 +6902,6 @@ snapshots:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-
-  patch-package@8.0.0:
-    dependencies:
-      '@yarnpkg/lockfile': 1.1.0
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      cross-spawn: 7.0.6
-      find-yarn-workspace-root: 2.0.0
-      fs-extra: 9.1.0
-      json-stable-stringify: 1.1.1
-      klaw-sync: 6.0.0
-      minimist: 1.2.8
-      open: 7.4.2
-      rimraf: 2.7.1
-      semver: 7.6.3
-      slash: 2.0.0
-      tmp: 0.0.33
-      yaml: 2.6.1
 
   path-exists@4.0.0: {}
 
@@ -7232,10 +7105,6 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rimraf@2.7.1:
-    dependencies:
-      glob: 7.2.3
-
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
@@ -7366,8 +7235,6 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
-
-  slash@2.0.0: {}
 
   slash@3.0.0: {}
 
@@ -7543,10 +7410,6 @@ snapshots:
 
   titleize@1.0.0: {}
 
-  tmp@0.0.33:
-    dependencies:
-      os-tmpdir: 1.0.2
-
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -7627,8 +7490,6 @@ snapshots:
       which-boxed-primitive: 1.0.2
 
   undici-types@6.19.8: {}
-
-  universalify@2.0.1: {}
 
   update-browserslist-db@1.1.1(browserslist@4.24.2):
     dependencies:
@@ -7831,8 +7692,6 @@ snapshots:
   yaml@2.3.4: {}
 
   yaml@2.5.1: {}
-
-  yaml@2.6.1: {}
 
   yocto-queue@0.1.0: {}
 

--- a/src/components/asset/AssetTable/AssetTable.tsx
+++ b/src/components/asset/AssetTable/AssetTable.tsx
@@ -93,7 +93,7 @@ export function AssetTable({
           <TableBody>
             {assets.length > 0 ? (
               assets.map((asset) => (
-                <TableRow key={asset.ticker}>
+                <TableRow key={asset.assetId}>
                   <TableCell>
                     <GenericLink href={`${ROUTES.Asset}/${asset.assetId}`}>
                       {asset.ticker || truncateAddress(asset.assetId, 4)}

--- a/src/components/identity/details/IdentityDetailsTabs/AssetTabTable.tsx
+++ b/src/components/identity/details/IdentityDetailsTabs/AssetTabTable.tsx
@@ -42,7 +42,7 @@ export function AssetTabTable({ assets }: AssetTabTableProps) {
           <TableBody>
             {paginatedAssets.length > 0 ? (
               paginatedAssets.map((asset) => (
-                <TableRow key={asset.ticker}>
+                <TableRow key={asset.assetId}>
                   <TableCell>
                     <GenericLink href={`${ROUTES.Asset}/${asset.assetId}`}>
                       {asset.name}

--- a/src/components/identity/details/IdentityDetailsTabs/PortfoliosTab/GroupedTabsFungibleOrNon/TabTokenMovementsTable.tsx
+++ b/src/components/identity/details/IdentityDetailsTabs/PortfoliosTab/GroupedTabsFungibleOrNon/TabTokenMovementsTable.tsx
@@ -23,6 +23,7 @@ import { truncateAddress } from '@/services/polymesh/address';
 import { PolymeshExplorerLink } from '@/components/shared/ExplorerLink/PolymeshExplorerLink';
 import { AccountOrDidTextField } from '@/components/shared/fieldAttributes/AccountOrDidTextField';
 import { TruncatedPortfolioNameWithTooltip } from '@/components/shared/fieldAttributes/TruncatedPortfolioNameWithTooltip';
+import { removeLeadingZeros } from '@/utils/formatString';
 
 interface TabTokenMovementsTableProps {
   portfolioMovements: PaginatedData<PortfolioMovement[]> | undefined;
@@ -32,11 +33,20 @@ interface TabTokenMovementsTableProps {
   assetType?: AssetTypeSelected;
 }
 
+const removeMovementIdPadding = (id: string) => {
+  if (!id) return '';
+  const [part1, part2] = id.split('/');
+  const formattedPart1 = removeLeadingZeros(part1);
+  const formattedPart2 = removeLeadingZeros(part2);
+  return `${formattedPart1}-${formattedPart2}`;
+};
+
 const formatMovementId = (id: string | undefined) => {
   if (!id) return '';
-  if (id.length <= 7) return id;
+  const unpaddedId = removeMovementIdPadding(id);
+  if (unpaddedId.length <= 7) return unpaddedId;
 
-  return `${id.slice(0, 3)}...${id.slice(-4)}`;
+  return `${unpaddedId.slice(0, 3)}...${unpaddedId.slice(-4)}`;
 };
 
 export function TabTokenMovementsTable({
@@ -92,6 +102,7 @@ export function TabTokenMovementsTable({
                           sx={{
                             overflow: 'hidden',
                             textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
                           }}
                         >
                           {formatMovementId(movement.id)}
@@ -100,7 +111,7 @@ export function TabTokenMovementsTable({
                           <PolymeshExplorerLink
                             baseUrl={subscanUrl}
                             path="extrinsic"
-                            hash={movement.id.replace('/', '-')}
+                            hash={removeMovementIdPadding(movement.id)}
                             sx={{
                               '& .MuiSvgIcon-root': {
                                 fontSize: '16px',
@@ -110,7 +121,7 @@ export function TabTokenMovementsTable({
                                 color: 'primary.main',
                               },
                             }}
-                            toolTipText={`See in subscan extrinsic ${movement.id.replace('/', '-')}`}
+                            toolTipText={`See in subscan extrinsic ${removeMovementIdPadding(movement.id)}`}
                           />
                         )}
                       </Box>

--- a/src/components/identity/details/IdentityDetailsTabs/SettlementInstructionsTab/RowInstruction.tsx
+++ b/src/components/identity/details/IdentityDetailsTabs/SettlementInstructionsTab/RowInstruction.tsx
@@ -82,8 +82,8 @@ export function RowInstruction({
         </TableCell>
         {isHistorical && (
           <TableCell>
-            {instruction.upatedAt ? (
-              <FormattedDate date={instruction.upatedAt} />
+            {instruction.updatedAt ? (
+              <FormattedDate date={instruction.updatedAt} />
             ) : (
               <EmptyDash />
             )}

--- a/src/components/settlement/SettlementCard/index.tsx
+++ b/src/components/settlement/SettlementCard/index.tsx
@@ -36,14 +36,14 @@ export function getLastEvent(
 
 export function generateLinkToUse(
   isExecuted: boolean,
-  lasEvent: RawInstructionEvent | null | undefined,
+  lastEvent: RawInstructionEvent | null | undefined,
   instruction: SettlementInstructionWithEvents | null | undefined,
 ): string {
   if (!instruction) return '';
 
-  return isExecuted && lasEvent
-    ? `${lasEvent.createdBlock.id.toString()}?tab=event&event=${lasEvent.id.replace('/', '-')}`
-    : instruction?.createdBlock?.id.toString() || '';
+  return isExecuted && lastEvent
+    ? `${lastEvent.createdBlock.blockId}?tab=event&event=${lastEvent.createdBlock.blockId}-${lastEvent.eventIdx}`
+    : `${instruction.createdBlock.blockId}?tab=event&event=${instruction.createdBlock.blockId}-${instruction.createdEvent.eventIdx}`;
 }
 
 interface SettlementCardProps {
@@ -62,8 +62,8 @@ export function SettlementCard({
   }
 
   const { id, createdAt, settlementType, isExecuted } = instruction;
-  const lasEvent = instruction ? getLastEvent(instruction) : null;
-  const linkToUse = generateLinkToUse(isExecuted, lasEvent, instruction);
+  const lastEvent = instruction ? getLastEvent(instruction) : null;
+  const linkToUse = generateLinkToUse(isExecuted, lastEvent, instruction);
 
   return (
     <>
@@ -105,8 +105,8 @@ export function SettlementCard({
             <Typography variant="body2" color="textSecondary">
               Execution Date:
             </Typography>
-            {isExecuted && instruction.upatedAt ? (
-              <FormattedDate date={instruction.upatedAt} variant="body1" />
+            {isExecuted && instruction.updatedAt ? (
+              <FormattedDate date={instruction.updatedAt} variant="body1" />
             ) : (
               <EmptyDash />
             )}

--- a/src/components/settlement/buildLinkFromEvent.ts
+++ b/src/components/settlement/buildLinkFromEvent.ts
@@ -4,7 +4,9 @@ export function buildLinkFromEvent(
   event: RawInstructionEvent,
   linkWithEvent: boolean = false,
 ) {
+  const { blockId } = event.createdBlock;
+
   return !linkWithEvent
-    ? event?.createdBlock?.id.toString()
-    : `${event.createdBlock.id.toString()}?tab=event&event=${event.id.replace('/', '-')}`;
+    ? blockId.toString()
+    : `${blockId.toString()}?tab=event&event=${blockId}-${event.eventIdx}`;
 }

--- a/src/components/settlement/tabs/EventsTabTable.tsx
+++ b/src/components/settlement/tabs/EventsTabTable.tsx
@@ -41,8 +41,8 @@ export function EventsTabTable({
           <TableRow>
             <TableCell>Date</TableCell>
             <TableCell>Event</TableCell>
-            <TableCell>Block</TableCell>
-            <TableCell>Hash</TableCell>
+            <TableCell>Event ID</TableCell>
+            <TableCell>Block Hash</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -53,11 +53,11 @@ export function EventsTabTable({
               </TableCell>
               <TableCell>{event.event}</TableCell>
               <TableCell>
-                {event.createdBlock.id}
+                {event.createdBlock.blockId}-{event.eventIdx}
                 <PolymeshExplorerLink
                   baseUrl={subscanUrl}
                   path="block"
-                  hash={buildLinkFromEvent(event)}
+                  hash={buildLinkFromEvent(event, true)}
                 />
               </TableCell>
               <TableCell>

--- a/src/config/constant.ts
+++ b/src/config/constant.ts
@@ -5,11 +5,16 @@ export const POLYMESH_DOCS = 'https://developers.polymesh.network/docs/';
 
 // network config nodes
 export const POLYMESH_RPC_URL = 'wss://mainnet-rpc.polymesh.network';
-export const GRAPHQL_ENDPOINT = 'https://mainnet-graphql.polymesh.network';
+
+export const GRAPHQL_ENDPOINT =
+  process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT ||
+  'https://mainnet-graphql.polymesh.network';
 export const SUBSCAN_URL = 'https://polymesh.subscan.io/';
 
 export const POLYMESH_RPC_URL_TESTNET = 'wss://testnet-rpc.polymesh.live';
-export const GRAPHQL_ENDPOINT_TESTNET = 'https://testnet-graphql.polymesh.live';
+export const GRAPHQL_ENDPOINT_TESTNET =
+  process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT_TESTNET ||
+  'https://testnet-graphql.polymesh.live';
 export const SUBSCAN_URL_TESTNET = 'https://polymesh-testnet.subscan.io/';
 // export const GRAPHQL_ENDPOINT_TESTNET = 'http://dev.polymesh.tech:3049';
 

--- a/src/domain/entities/SettlementInstruction.ts
+++ b/src/domain/entities/SettlementInstruction.ts
@@ -25,17 +25,22 @@ export interface SettlementInstruction {
   venueDescription?: string;
   status: InstructionStatus;
   memo: string | null;
-  createdAt?: Date;
-  upatedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
   counterparties: number;
   affirmedBy: number;
   settlementType: string;
   legs: SettlementLeg[];
   isExecuted: boolean;
-  createdBlock?: RawBlock;
+  createdBlock: RawBlock;
+  createdEvent: {
+    id: string;
+    eventId: string;
+    eventIdx: number;
+  };
 }
 
-type RawAffirmationNodeExtended = Omit<RawAffirmationNode, 'createdAt'> & {
+type RawAffirmationNodeExtended = RawAffirmationNode & {
   createdAt: Date;
 };
 

--- a/src/services/polymesh/sdk/assetsService.ts
+++ b/src/services/polymesh/sdk/assetsService.ts
@@ -77,7 +77,7 @@ export async function getCollectionsFromPortfolio(
     await portfolio.getCollections();
   return Promise.all(
     collectionsList.map(async ({ collection, free, locked, total }) => {
-      const [{ name, assetType }, collectionId] = await Promise.all([
+      const [{ name, assetType, ticker }, collectionId] = await Promise.all([
         collection.details(),
         collection.getCollectionId(),
       ]);
@@ -85,7 +85,7 @@ export async function getCollectionsFromPortfolio(
       const imgUrl = await getNftImageUrl(free[0] || locked[0]);
       return {
         collectionId: collectionId.toString(),
-        ticker: collection.ticker,
+        ticker,
         assetId: collection.id,
         imgUrl: imgUrl || '',
         uuid: collection.uuid,
@@ -103,7 +103,7 @@ export async function getNftAssetsFromPortfolio(
   const collectionsList = await portfolio.getCollections();
   const parsedNftsList = await Promise.all(
     collectionsList.map(async ({ free, locked, collection: rawCollection }) => {
-      const { name: collectionName } = await rawCollection.details();
+      const { name: collectionName, ticker } = await rawCollection.details();
       const freeNfts = await Promise.all(
         free.map(async (nft) => {
           let imgUrl = imageUrlCache.get(nft.uuid);
@@ -116,7 +116,7 @@ export async function getNftAssetsFromPortfolio(
             id: nft.id.toNumber(),
             imgUrl,
             isLocked: false,
-            collectionTicker: rawCollection.ticker,
+            collectionTicker: ticker,
             assetId: rawCollection.id,
             collectionName,
           };
@@ -134,7 +134,7 @@ export async function getNftAssetsFromPortfolio(
             id: nft.id.toNumber(),
             imgUrl,
             isLocked: true,
-            collectionTicker: rawCollection.ticker,
+            collectionTicker: ticker,
             assetId: rawCollection.id,
             collectionName,
           };

--- a/src/services/repositories/AssetGraphRepo.ts
+++ b/src/services/repositories/AssetGraphRepo.ts
@@ -59,7 +59,7 @@ export class AssetGraphRepo {
         assets(
           first: $first
           after: $after
-          orderBy: [CREATED_AT_DESC]
+          orderBy: [CREATED_EVENT_ID_DESC]
           filter: { isNftCollection: { equalTo: $isNftCollection } }
         ) {
           totalCount
@@ -77,7 +77,7 @@ export class AssetGraphRepo {
       ${assetFragment}
       ${pageInfoFragment}
       query ($first: Int!, $after: Cursor) {
-        assets(first: $first, after: $after, orderBy: [CREATED_AT_DESC]) {
+        assets(first: $first, after: $after, orderBy: [CREATED_EVENT_ID_DESC]) {
           totalCount
           pageInfo {
             ...PageInfoFields

--- a/src/services/repositories/AssetTransactionGraphRepo.ts
+++ b/src/services/repositories/AssetTransactionGraphRepo.ts
@@ -58,7 +58,7 @@ export class AssetTransactionGraphRepo {
         assetTransactions(
           first: $pageSize
           after: $after
-          orderBy: CREATED_AT_DESC
+          orderBy: CREATED_EVENT_ID_DESC
           filter: {
             ${filterConditions}
           }

--- a/src/services/repositories/ExtrinsicGraphRepo.ts
+++ b/src/services/repositories/ExtrinsicGraphRepo.ts
@@ -21,7 +21,7 @@ export class ExtrinsicGraphRepo {
       return `
         did_${did}: extrinsics(
           filter: {address: {in: [${addressFilter}]}}
-          orderBy: [CREATED_AT_DESC]
+          orderBy: [ID_DESC]
           first: ${size}
           offset: ${start}
         ) {
@@ -88,7 +88,7 @@ export class ExtrinsicGraphRepo {
       query TransactionsQuery($start: Int, $size: Int, $addresses: [String!]!) {
         extrinsics(
           filter: { address: { in: $addresses } }
-          orderBy: [CREATED_AT_DESC]
+          orderBy: [ID_DESC]
           first: $size
           offset: $start
         ) {

--- a/src/services/repositories/IdentityGraphRepo.ts
+++ b/src/services/repositories/IdentityGraphRepo.ts
@@ -74,7 +74,11 @@ export class IdentityGraphRepo {
       ${identityFragment}
       ${pageInfoFragment}
       query ($first: Int!, $after: Cursor) {
-        identities(first: $first, after: $after, orderBy: CREATED_AT_DESC) {
+        identities(
+          first: $first
+          after: $after
+          orderBy: CREATED_BLOCK_ID_DESC
+        ) {
           totalCount
           pageInfo {
             ...PageInfoFields

--- a/src/services/repositories/InstructionGraphRepo.ts
+++ b/src/services/repositories/InstructionGraphRepo.ts
@@ -104,6 +104,7 @@ export class InstructionGraphRepo {
         instructions(
           first: $pageSize
           offset: $offset
+          orderBy: CREATED_EVENT_ID_DESC
           filter: {
             and: [
               {
@@ -179,6 +180,7 @@ export class InstructionGraphRepo {
         instructions(
           first: $pageSize
           offset: $offset
+          orderBy: CREATED_EVENT_ID_DESC
           filter: {
             and: [
               { venueId: { equalTo: $venueId } }

--- a/src/services/repositories/PortfolioMovementsGraphRepo.ts
+++ b/src/services/repositories/PortfolioMovementsGraphRepo.ts
@@ -28,7 +28,7 @@ export class PortfolioMovementsGraphRepo {
         portfolioMovements(
           first: $pageSize
           offset: $offset
-          orderBy: CREATED_AT_DESC
+          orderBy: ID_DESC
           filter: {
             type: { equalTo: $type }
             or: [

--- a/src/services/repositories/VenueGraphRepo.ts
+++ b/src/services/repositories/VenueGraphRepo.ts
@@ -43,7 +43,7 @@ export class VenueGraphRepo {
       ${venueFragment}
       ${pageInfoFragment}
       query ($first: Int!, $after: Cursor) {
-        venues(first: $first, after: $after, orderBy: CREATED_AT_DESC) {
+        venues(first: $first, after: $after, orderBy: CREATED_BLOCK_ID_DESC) {
           totalCount
           pageInfo {
             ...PageInfoFields

--- a/src/services/repositories/fragments.ts
+++ b/src/services/repositories/fragments.ts
@@ -64,7 +64,10 @@ export const identityFragment = gql`
     portfolios(filter: { deletedAt: { isNull: true } }) {
       totalCount
     }
-    heldAssets {
+    heldAssets(
+      orderBy: ASSET_ID_ASC
+      filter: { amount: { greaterThan: "0" } }
+    ) {
       totalCount
       nodes {
         asset {
@@ -72,13 +75,13 @@ export const identityFragment = gql`
         }
       }
     }
-    assetsByOwnerId {
+    assetsByOwnerId(orderBy: [NAME_ASC, TICKER_ASC, ID_ASC]) {
       totalCount
       nodes {
         ...AssetFields
       }
     }
-    heldNfts {
+    heldNfts(orderBy: ASSET_ID_ASC, filter: { nftIds: { notEqualTo: [] } }) {
       totalCount
       nodes {
         asset {
@@ -153,12 +156,14 @@ export const settlementInstructionFragment = gql`
       }
     }
     memo
-    affirmations {
+    affirmations(orderBy: CREATED_BLOCK_ID_DESC) {
       nodes {
         identity
         isAutomaticallyAffirmed
         isMediator
-        createdAt
+        createdBlock {
+          datetime
+        }
         createdBlockId
         status
         portfolios
@@ -172,6 +177,11 @@ export const settlementInstructionFragment = gql`
       datetime
       hash
     }
+    createdEvent {
+      id
+      eventId
+      eventIdx
+    }
     updatedBlock {
       id
       blockId
@@ -182,8 +192,10 @@ export const settlementInstructionFragment = gql`
       nodes {
         id
         event
+        eventIdx
         createdBlock {
           id
+          blockId
           datetime
           hash
         }

--- a/src/services/repositories/types.ts
+++ b/src/services/repositories/types.ts
@@ -262,7 +262,7 @@ export interface ExtrinsicResponse {
 // Instruction
 export interface RawBlock {
   id: string;
-  blockId?: number;
+  blockId: number;
   datetime: string;
   hash: string;
 }
@@ -270,6 +270,7 @@ export interface RawBlock {
 export interface RawInstructionEvent {
   id: string;
   event: string;
+  eventIdx: number;
   createdBlock: RawBlock;
 }
 
@@ -291,7 +292,9 @@ export interface RawAffirmationNode {
   identity: string;
   isAutomaticallyAffirmed: boolean;
   isMediator: boolean;
-  createdAt: string;
+  createdBlock: {
+    datetime: string;
+  };
   createdBlockId: string;
   status: string;
   portfolios: number[] | null;
@@ -322,6 +325,11 @@ export interface RawInstructionNode {
   mediators: string[];
   failureReason: string | null;
   createdBlock: RawBlock;
+  createdEvent: {
+    id: string;
+    eventId: string;
+    eventIdx: number;
+  };
   updatedBlock: RawBlock;
   events: {
     nodes: RawInstructionEvent[];

--- a/src/services/transformers/instructionsTransformer.ts
+++ b/src/services/transformers/instructionsTransformer.ts
@@ -64,12 +64,8 @@ export function rawInstructiontoSettlementInstruction(
     venueDescription: rawInstruction.venue?.details,
     status: statusEnumToInstructionStatus(rawInstruction.status),
     memo: rawInstruction.memo,
-    createdAt: rawInstruction.createdBlock.datetime
-      ? new Date(`${rawInstruction.createdBlock.datetime}Z`)
-      : undefined,
-    upatedAt: rawInstruction.updatedBlock.datetime
-      ? new Date(`${rawInstruction.updatedBlock.datetime}Z`)
-      : undefined,
+    createdAt: new Date(`${rawInstruction.createdBlock.datetime}Z`),
+    updatedAt: new Date(`${rawInstruction.updatedBlock.datetime}Z`),
     counterparties: uniqueCounterparties.size,
     affirmedBy: rawInstruction.affirmations.nodes.filter(
       (a) => a.status === 'Affirmed',
@@ -80,7 +76,9 @@ export function rawInstructiontoSettlementInstruction(
     events: rawInstruction.events.nodes,
     affirmations: rawInstruction.affirmations.nodes.map((a) => ({
       ...a,
-      createdAt: new Date(`${a.createdAt}Z`),
+      createdAt: new Date(`${a.createdBlock.datetime}Z`),
     })),
+    createdBlock: rawInstruction.createdBlock,
+    createdEvent: rawInstruction.createdEvent,
   };
 }

--- a/src/utils/formatString.ts
+++ b/src/utils/formatString.ts
@@ -20,3 +20,7 @@ export function splitCamelCase(text: string): string {
 
   return text;
 }
+
+export function removeLeadingZeros(str: string) {
+  return str.replace(/^0+/, '');
+}


### PR DESCRIPTION
This PR:
- updated the Polymesh SDK to version 27.3.0
- removed `createdAt` from GraphQL queries as it is no longer supported in v19
- removed orderBy: CREATED_AT_DESC and replaced with EVENT_ID_DESC, BLOCK_ID_DESC or ID_DESC to ensure correct chronological ordering
- when using the SDK asset tickers are not retrieved from asset.details
- SQ v19 introduced padding Block ID, Event ID and Extrinsic ID with 0's for a consistent length to ensure ordering matched numerical ordering when ordering by ID. Where the ID are required e.g. for display or creation of Subscan links they have been replaced with a numberical Idx or the padding is removed.